### PR TITLE
web adapter 예시 추가

### DIFF
--- a/src/main/java/com/hansol/bloomingspring/hexagonal/account/adapter/in/web/RegisterAccountController.java
+++ b/src/main/java/com/hansol/bloomingspring/hexagonal/account/adapter/in/web/RegisterAccountController.java
@@ -1,0 +1,35 @@
+package com.hansol.bloomingspring.hexagonal.account.adapter.in.web;
+
+import com.hansol.bloomingspring.hexagonal.account.application.port.in.RegisterAccountCommand;
+import com.hansol.bloomingspring.hexagonal.account.application.port.in.RegisterAccountUseCase;
+import com.hansol.bloomingspring.hexagonal.common.WebAdapter;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@WebAdapter
+@RestController
+@RequiredArgsConstructor
+public class RegisterAccountController {
+
+    private final RegisterAccountUseCase registerAccountUseCase;
+
+    @PostMapping(params = "/accounts")
+    Long registerAccount(
+            @RequestBody RegisterAccountRequest registerAccountRequest
+    ) {
+
+        RegisterAccountCommand command = new RegisterAccountCommand(
+                registerAccountRequest.getName()
+        );
+
+        return registerAccountUseCase.registerAccount(command);
+    }
+
+    @Value
+    private static class RegisterAccountRequest {
+        private String name;
+    }
+}

--- a/src/main/java/com/hansol/bloomingspring/hexagonal/account/adapter/out/persistence/AccountJpaEntity.java
+++ b/src/main/java/com/hansol/bloomingspring/hexagonal/account/adapter/out/persistence/AccountJpaEntity.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
@@ -20,5 +21,7 @@ class AccountJpaEntity {
     @GeneratedValue
     private Long id;
 
+    @Column
+    private String name;
 }
 

--- a/src/main/java/com/hansol/bloomingspring/hexagonal/account/adapter/out/persistence/AccountMapper.java
+++ b/src/main/java/com/hansol/bloomingspring/hexagonal/account/adapter/out/persistence/AccountMapper.java
@@ -29,6 +29,13 @@ class AccountMapper {
 
     }
 
+    AccountJpaEntity mapToJpaEntity(String name) {
+        return new AccountJpaEntity(
+                null,
+                name
+        );
+    }
+
     ActivityWindow mapToActivityWindow(List<ActivityJpaEntity> activities) {
         List<Activity> mappedActivities = new ArrayList<>();
 

--- a/src/main/java/com/hansol/bloomingspring/hexagonal/account/adapter/out/persistence/AccountPersistenceAdapter.java
+++ b/src/main/java/com/hansol/bloomingspring/hexagonal/account/adapter/out/persistence/AccountPersistenceAdapter.java
@@ -13,7 +13,8 @@ import java.util.List;
 
 @RequiredArgsConstructor
 @PersistenceAdapter
-public class AccountPersistenceAdapter implements LoadAccountPort, UpdateAccountStatePort {
+public class AccountPersistenceAdapter implements
+        LoadAccountPort, UpdateAccountStatePort {
 
     private final SpringDataAccountRepository accountRepository;
     private final ActivityRepository activityRepository;

--- a/src/main/java/com/hansol/bloomingspring/hexagonal/account/application/port/in/RegisterAccountCommand.java
+++ b/src/main/java/com/hansol/bloomingspring/hexagonal/account/application/port/in/RegisterAccountCommand.java
@@ -1,0 +1,22 @@
+package com.hansol.bloomingspring.hexagonal.account.application.port.in;
+
+import com.hansol.bloomingspring.hexagonal.common.SelfValidating;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+
+import javax.validation.constraints.NotNull;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class RegisterAccountCommand extends SelfValidating<RegisterAccountCommand> {
+
+    @NotNull
+    private final String name;
+
+    public RegisterAccountCommand(
+            String name
+    ) {
+        this.name = name;
+        this.validateSelf();
+    }
+}

--- a/src/main/java/com/hansol/bloomingspring/hexagonal/account/application/port/in/RegisterAccountUseCase.java
+++ b/src/main/java/com/hansol/bloomingspring/hexagonal/account/application/port/in/RegisterAccountUseCase.java
@@ -1,0 +1,7 @@
+package com.hansol.bloomingspring.hexagonal.account.application.port.in;
+
+public interface RegisterAccountUseCase {
+
+    Long registerAccount(RegisterAccountCommand command);
+
+}

--- a/src/main/java/com/hansol/bloomingspring/hexagonal/account/application/port/out/RegisterAccountPort.java
+++ b/src/main/java/com/hansol/bloomingspring/hexagonal/account/application/port/out/RegisterAccountPort.java
@@ -1,0 +1,7 @@
+package com.hansol.bloomingspring.hexagonal.account.application.port.out;
+
+public interface RegisterAccountPort {
+
+    Long registerAccount(String name);
+
+}

--- a/src/main/java/com/hansol/bloomingspring/hexagonal/account/application/service/RegisterAccountService.java
+++ b/src/main/java/com/hansol/bloomingspring/hexagonal/account/application/service/RegisterAccountService.java
@@ -1,0 +1,22 @@
+package com.hansol.bloomingspring.hexagonal.account.application.service;
+
+import com.hansol.bloomingspring.hexagonal.account.application.port.in.RegisterAccountCommand;
+import com.hansol.bloomingspring.hexagonal.account.application.port.in.RegisterAccountUseCase;
+import com.hansol.bloomingspring.hexagonal.account.application.port.out.RegisterAccountPort;
+import com.hansol.bloomingspring.hexagonal.common.UseCase;
+import lombok.RequiredArgsConstructor;
+
+import javax.transaction.Transactional;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional
+public class RegisterAccountService implements RegisterAccountUseCase {
+
+    private final RegisterAccountPort registerAccountPort;
+
+    @Override
+    public Long registerAccount(RegisterAccountCommand command) {
+        return registerAccountPort.registerAccount(command.getName());
+    }
+}


### PR DESCRIPTION
web adapter를 작은 클래스로 나눌 때 장점

데이터 구조 재사용을 막을 수 있음
테스트 코드 찾기 쉬움
여러 개발자가 개발 시 충돌 방지